### PR TITLE
optimize testsuite parsing conditions

### DIFF
--- a/xunitparser.py
+++ b/xunitparser.py
@@ -171,11 +171,11 @@ class Parser(object):
         for el in root:
             if el.tag == 'testcase':
                 self.parse_testcase(el, ts)
-            if el.tag == 'properties':
+            elif el.tag == 'properties':
                 self.parse_properties(el, ts)
-            if el.tag == 'system-out' and el.text:
+            elif el.tag == 'system-out' and el.text:
                 ts.stdout = el.text.strip()
-            if el.tag == 'system-err' and el.text:
+            elif el.tag == 'system-err' and el.text:
                 ts.stderr = el.text.strip()
 
     def parse_testcase(self, el, ts):
@@ -200,7 +200,7 @@ class Parser(object):
                 tc.time = to_timedelta(el.attrib.get('time'))
             if e.tag == 'system-out' and e.text:
                 tc.stdout = e.text.strip()
-            if e.tag == 'system-err' and e.text:
+            elif e.tag == 'system-err' and e.text:
                 tc.stderr = e.text.strip()
 
         # add either the original "success" tc or a tc created by elements


### PR DESCRIPTION
Parsing of testsuite could be optimized, because el.tag cannot be a 'testcase' and 'properties' at same time, so other conditions are unnecessary
